### PR TITLE
Point in polygon

### DIFF
--- a/include/djp/geometry/winding_number.hpp
+++ b/include/djp/geometry/winding_number.hpp
@@ -1,0 +1,50 @@
+//          Copyright Jorge Aguirre August 2015
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#ifndef DJP_GEOMETRY_POINT_IN_POLYGON_HPP
+#define DJP_GEOMETRY_POINT_IN_POLYGON_HPP
+
+#include <algorithm> // For std::next
+#include <cstdint>   // For std::int64_t
+#include <vector>    // For std::vector
+
+namespace djp {
+/// \brief Uses winding number test for a point in a polygon.
+///
+/// Computes how many times the polygon \p poly winds around the point \p p0. A
+/// point is outside only when the polygon doesn't wind around the point at all
+/// which is when the winding number <tt>wn = 0</tt>.
+///
+/// \param p0 The point to test.
+/// \param poly The polygon beign tested.
+///
+/// \par Complexity
+/// Linear <tt>O(n)</tt> where <tt>n = poly.size()</tt>
+///
+/// \return \c true if point \p p0 is in polygon.
+///
+template <typename Point>
+bool point_in_polygon(const Point &p0, const std::vector<Point> &poly) {
+  std::int64_t wn = 0;
+
+  auto check_crossing = [&](const Point &q0, const Point &q1) {
+    if (q0.y <= p0.y) {
+      if (q1.y > p0.y)
+        wn += ((q1 - q0) ^ (p0 - q0)) > 0;
+    } else {
+      if (q1.y <= p0.y)
+        wn -= ((q1 - q0) ^ (p0 - q0)) < 0;
+    }
+  };
+
+  std::size_t N = poly.size();
+  for (std::size_t i = 0; i + 1 < N; ++i)
+    check_crossing(poly[i], poly[i + 1]);
+  check_crossing(poly[N - 1], poly[0]);
+
+  return wn != 0;
+}
+}
+#endif // HEADER GUARD

--- a/include/djp/geometry/winding_number.hpp
+++ b/include/djp/geometry/winding_number.hpp
@@ -6,9 +6,9 @@
 #ifndef DJP_GEOMETRY_POINT_IN_POLYGON_HPP
 #define DJP_GEOMETRY_POINT_IN_POLYGON_HPP
 
-#include <algorithm> // For std::next
-#include <cstdint>   // For std::int64_t
-#include <vector>    // For std::vector
+#include <cstddef> // For std::size_t
+#include <cstdint> // For std::int64_t
+#include <vector>  // For std::vector
 
 namespace djp {
 /// \brief Uses winding number test for a point in a polygon.

--- a/test/geometry/CMakeLists.txt
+++ b/test/geometry/CMakeLists.txt
@@ -3,6 +3,7 @@ set(GEOMETRY_TEST_SOURCES
   "point_2d_test.cpp"
   "point_order_test.cpp"
   "segment_intersection_test.cpp"
+  "winding_number.cpp"
   )
 
 add_unittest("geometry" ${GEOMETRY_TEST_SOURCES})

--- a/test/geometry/winding_number.cpp
+++ b/test/geometry/winding_number.cpp
@@ -1,0 +1,57 @@
+//          Copyright Jorge Aguirre August 2015
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <djp/geometry/winding_number.hpp>
+#include <gtest/gtest.h>
+
+#include <djp/geometry/point_2d.hpp>
+
+#include <vector>
+using namespace djp;
+
+using scalar_t = int;
+using point_t = point<scalar_t>;
+
+TEST(PointInPolygonTest, SimpleShapes) {
+  // A trinagle
+  std::vector<point_t> poly = {{1, 1}, {4, 3}, {2, 4}};
+  EXPECT_FALSE(point_in_polygon({6, 6}, poly));
+  EXPECT_TRUE(point_in_polygon({3, 3}, poly));
+
+  // A square
+  poly = {{0, 0}, {0, 4}, {4, 4}, {4, 0}};
+  EXPECT_FALSE(point_in_polygon({6, 6}, poly));
+  EXPECT_TRUE(point_in_polygon({2, 3}, poly));
+}
+
+TEST(PointInPolygonTest, ColinearPoint) {
+  std::vector<point_t> poly = {{0, 0}, {0, 4}, {4, 4}, {4, 0}};
+
+  EXPECT_FALSE(point_in_polygon({-1, 0}, poly));
+  EXPECT_FALSE(point_in_polygon({5, 0}, poly));
+  EXPECT_FALSE(point_in_polygon({0, 6}, poly));
+  EXPECT_FALSE(point_in_polygon({4, 6}, poly));
+
+  poly = {{0, 0}, {1, 1}, {2, 0}};
+
+  EXPECT_FALSE(point_in_polygon({2, 2}, poly));
+  EXPECT_FALSE(point_in_polygon({0, 2}, poly));
+  EXPECT_FALSE(point_in_polygon({-1, 0}, poly));
+  EXPECT_FALSE(point_in_polygon({3, 0}, poly));
+  EXPECT_FALSE(point_in_polygon({3, -1}, poly));
+  EXPECT_FALSE(point_in_polygon({-1, -1}, poly));
+}
+
+TEST(PointInPolygonTest, NonConvexPolygon) {
+  std::vector<point_t> poly = {{1, 1}, {3, 0}, {4, 2}, {6, 1},
+                               {3, 6}, {4, 3}, {2, 4}};
+  EXPECT_TRUE(point_in_polygon({2, 3}, poly));
+  EXPECT_TRUE(point_in_polygon({5, 2}, poly));
+  EXPECT_TRUE(point_in_polygon({4, 4}, poly));
+
+  EXPECT_FALSE(point_in_polygon({-1, -1}, poly));
+  EXPECT_FALSE(point_in_polygon({3, 4}, poly));
+  EXPECT_FALSE(point_in_polygon({4, 1}, poly));
+}

--- a/test/geometry/winding_number.cpp
+++ b/test/geometry/winding_number.cpp
@@ -8,10 +8,12 @@
 
 #include <djp/geometry/point_2d.hpp>
 
-#include <vector>
+#include <vector>  // For std::vector
+#include <cstdint> // For std::int32_t
+
 using namespace djp;
 
-using scalar_t = int;
+using scalar_t = std::int32_t;
 using point_t = point<scalar_t>;
 
 TEST(PointInPolygonTest, SimpleShapes) {

--- a/ç
+++ b/ç
@@ -1,0 +1,21 @@
+//          Copyright Jorge Aguirre August 2015
+// Distributed under the Boost Software License, Version 1.0.
+//    (See accompanying file LICENSE_1_0.txt or copy at
+//          http://www.boost.org/LICENSE_1_0.txt)
+
+#include <djp/geometry/winding_number.hpp>
+#include <gtest/gtest.h>
+
+#include <djp/geometry/point_2d.hpp>
+
+#include <vector>
+using namespace djp;
+
+using scalar_t = int;
+using point_t = point<scalar_t>;
+
+TEST(PointInPolygonTest, SimpleShapes) {
+  // A trinagle
+  std::vector<point_t> poly = {{1, 1}, {4, 3}, {2, 4}};
+  EXPECT_FALSE(point_in_polygon({6, 6}, poly));
+}


### PR DESCRIPTION
Add winding number test for a point in a polygon. The approach used is helpful since is cheap to compute and has the same correctness that the original [algorithm](http://www.engr.colostate.edu/~dga/dga/papers/point_in_polygon.pdf).
