### PR TITLE
Tidy 3.9 - All except 'geometry' module.

### DIFF
--- a/include/cpl/data_structure/disjoint_set.hpp
+++ b/include/cpl/data_structure/disjoint_set.hpp
@@ -27,8 +27,10 @@ public:
   /// Linear in the number of elements.
   ///
   explicit disjoint_set(size_t n) : parent(new size_t[n]), rank(new size_t[n]) {
-    for (size_t x = 0; x != n; ++x)
-      parent[x] = x, rank[x] = 0;
+    for (size_t x = 0; x != n; ++x) {
+      parent[x] = x;
+      rank[x] = 0;
+    }
   }
 
   /// \brief Finds the representative element of the set containing \p x.
@@ -62,12 +64,15 @@ public:
     y = find_set(y);
     if (x == y)
       return false;
-    if (rank[x] < rank[y])
+
+    if (rank[x] < rank[y]) {
       parent[x] = y;
-    else if (rank[x] > rank[y])
+    } else if (rank[x] > rank[y]) {
       parent[y] = x;
-    else
-      parent[y] = x, ++rank[x];
+    } else {
+      parent[y] = x;
+      ++rank[x];
+    }
     return true;
   }
 };

--- a/include/cpl/data_structure/lazyprop_segtree.hpp
+++ b/include/cpl/data_structure/lazyprop_segtree.hpp
@@ -219,8 +219,8 @@ private:
 
 private:
   // Data variables
-  size_t num_elems;
-  Combine combine;
+  size_t num_elems{};
+  Combine combine{};
   std::vector<T> values;
   std::vector<OpList> ops;
   // Cache variables

--- a/include/cpl/graph/biconnected_components.hpp
+++ b/include/cpl/graph/biconnected_components.hpp
@@ -91,9 +91,12 @@ size_t biconnected_components(const Graph& g, std::vector<size_t>& bicomp,
     if (low[src] < dtm[parent])
       return;
     is_articulation[parent] = true;
-    while (dtm[stack.top().second] >= dtm[src])
-      bicomp[stack.top().first] = comp_cnt, stack.pop();
-    bicomp[stack.top().first] = comp_cnt++, stack.pop();
+    while (dtm[stack.top().second] >= dtm[src]) {
+      bicomp[stack.top().first] = comp_cnt;
+      stack.pop();
+    }
+    bicomp[stack.top().first] = comp_cnt++;
+    stack.pop();
   };
 
   for (size_t v = 0; v != num_vertices; ++v) {

--- a/include/cpl/graph/jump_pointer_tree.hpp
+++ b/include/cpl/graph/jump_pointer_tree.hpp
@@ -26,8 +26,10 @@ class jump_pointer_tree {
 private:
   static size_t parents_size(size_t depth) {
     size_t result = 0;
-    while (depth > 0)
-      ++result, depth >>= 1;
+    while (depth > 0) {
+      ++result;
+      depth >>= 1;
+    }
     return result;
   }
   void add_leaf(const size_t leaf, const size_t parent) {

--- a/include/cpl/graph/topological_sort.hpp
+++ b/include/cpl/graph/topological_sort.hpp
@@ -90,7 +90,7 @@ void prioritized_topological_sort(const Graph& g, Comp comp,
                                   UnaryFunction output_vertex) {
   const size_t num_vertices = g.num_vertices();
   const size_t num_edges = g.num_edges();
-  std::priority_queue<void, std::vector<size_t>, Comp> queue(comp);
+  std::priority_queue<size_t, std::vector<size_t>, Comp> queue(comp);
   std::vector<size_t> in_degree(num_vertices);
 
   for (size_t e = 0; e != num_edges; ++e)

--- a/include/cpl/math/matrix_ops.hpp
+++ b/include/cpl/math/matrix_ops.hpp
@@ -26,13 +26,14 @@ template <typename T>
 matrix<T> mat_mul(const matrix<T>& a, const matrix<T>& b) {
   assert(a.cols() == b.rows() && "Matrices cannot be multiplied");
   matrix<T> r({a.rows(), b.cols()});
-  for (size_t i = 0; i < r.rows(); ++i)
+  for (size_t i = 0; i < r.rows(); ++i) {
     for (size_t j = 0; j < r.cols(); ++j) {
       T sum = 0;
       for (size_t k = 0; k < a.cols(); ++k)
         sum += a[{i, k}] * b[{k, j}];
       r[{i, j}] = sum;
     }
+  }
   return r;
 }
 

--- a/include/cpl/math/rational.hpp
+++ b/include/cpl/math/rational.hpp
@@ -181,7 +181,7 @@ OutputIt continued_fraction(const rational<T>& r, OutputIt out_it) {
 ///
 template <typename T>
 rational<T> evaluate_continued_fraction(const std::vector<T>& coeffs) {
-  assert(coeffs.size() > 0);
+  assert(!coeffs.empty());
   rational<T> r{coeffs.back()};
   std::for_each(coeffs.rbegin() + 1, coeffs.rend(),
                 [&](const T& ai) { r = rational<T>(ai) + reciprocal(r); });

--- a/include/cpl/strings/dc3_suffix_array.hpp
+++ b/include/cpl/strings/dc3_suffix_array.hpp
@@ -101,10 +101,13 @@ inline std::vector<size_t> dc3_suffix_array(const std::string& str) {
     while (p < n0 && t < n02) {
       size_t i = get_pos(t); // pos of current offset 12 suffix
       size_t j = sa0[p];     // pos of current offset 0 suffix
-      if (suffix12_smaller(i, j))
-        sa[k++] = i, ++t;
-      else
-        sa[k++] = j, ++p;
+      if (suffix12_smaller(i, j)) {
+        sa[k++] = i;
+        ++t;
+      } else {
+        sa[k++] = j;
+        ++p;
+      }
     }
     while (p < n0)
       sa[k++] = sa0[p++];

--- a/include/cpl/strings/z_algorithm.hpp
+++ b/include/cpl/strings/z_algorithm.hpp
@@ -39,8 +39,10 @@ inline std::vector<size_t> z_algorithm(const std::string& str) {
       z[i] = std::min(r - i, z[i - l]);
     while (i + z[i] < n && str[z[i]] == str[i + z[i]])
       ++z[i];
-    if (i + z[i] > r)
-      l = i, r = i + z[i];
+    if (i + z[i] > r) {
+      l = i;
+      r = i + z[i];
+    }
   }
   return z;
 }

--- a/test/data_structure/lazyprop_segtree_test.cpp
+++ b/test/data_structure/lazyprop_segtree_test.cpp
@@ -167,10 +167,12 @@ TEST_F(LazypropSegtreeTest,
       return must_assign ? value : reduced_val + value;
     }
     op_list& push(const op_list& op) {
-      if (op.must_assign)
-        value = op.value, must_assign = true;
-      else
+      if (op.must_assign) {
+        value = op.value;
+        must_assign = true;
+      } else {
         value += op.value;
+      }
       return *this; // Just for convenience, not required
     }
   };

--- a/test/graph/gusfield_all_pairs_min_cut_test.cpp
+++ b/test/graph/gusfield_all_pairs_min_cut_test.cpp
@@ -13,7 +13,6 @@
 
 using cpl::gusfield_all_pairs_min_cut;
 using cpl::directed_graph;
-using cpl::matrix;
 using std::size_t;
 
 TEST(GusfieldAllPairsMinCutTest, SmallGraphTest) {

--- a/test/graph/min_st_cut_test.cpp
+++ b/test/graph/min_st_cut_test.cpp
@@ -7,13 +7,28 @@
 #include <gtest/gtest.h>
 
 #include <cpl/graph/directed_graph.hpp> // directed_graph
+#include <algorithm>                    // transform
+#include <cassert>                      // assert
 #include <cstddef>                      // size_t
+#include <iterator>                     // back_inserter
 #include <vector>                       // vector
 
 using cpl::min_st_cut;
 using cpl::directed_graph;
 using std::size_t;
+using std::back_inserter;
 using bool_vec = std::vector<bool>;
+
+static bool_vec make_bool_vec(const std::string& str) {
+  std::vector<bool> res;
+  res.reserve(str.size());
+  std::transform(begin(str), end(str), back_inserter(res), [](const char c) {
+    assert(c == '0' || c == '1');
+    return c == '1';
+  });
+  assert(res.size() == str.size());
+  return res;
+}
 
 static std::vector<size_t> get_cut_set(const directed_graph& g,
                                        bool_vec& source_side) {
@@ -54,7 +69,7 @@ TEST(MinSTCutTest, WorksForSmallCases) {
 
   bool_vec source_side;
   EXPECT_EQ(23, min_st_cut(graph, 0, 5, rev_edge, capacity, source_side));
-  ASSERT_EQ(bool_vec({1, 1, 1, 0, 1, 0}), source_side);
+  ASSERT_EQ(make_bool_vec("111010"), source_side);
 
   const auto cut_set = get_cut_set(graph, source_side);
 
@@ -102,7 +117,7 @@ TEST(MinSTCutTest, BidirGraphTest) {
 
   bool_vec source_side;
   EXPECT_EQ(2, min_st_cut(graph, 0, 11, rev_edge, capacity, source_side));
-  EXPECT_EQ(bool_vec({1, 1, 1, 1, 1, 1, 1, 0, 1, 1, 0, 0, 0}), source_side);
+  EXPECT_EQ(make_bool_vec("1111111011000"), source_side);
 
   const auto cut_set = get_cut_set(graph, source_side);
 

--- a/test/math/matrix_ops_test.cpp
+++ b/test/math/matrix_ops_test.cpp
@@ -34,12 +34,13 @@ template <typename T>
 static bool is_identity(const matrix<T>& mat) {
   if (!is_square(mat))
     return false;
-  for (size_t i = 0; i < mat.rows(); ++i)
+  for (size_t i = 0; i < mat.rows(); ++i) {
     for (size_t j = 0; j < mat.cols(); ++j) {
       T expected = (i == j) ? 1 : 0;
       if (mat[{i, j}] != expected)
         return false;
     }
+  }
   return true;
 }
 
@@ -49,10 +50,12 @@ template <typename T>
 static bool operator==(const matrix<T>& a, const matrix<T>& b) {
   if (a.rows() != b.rows() || a.cols() != b.cols())
     return false;
-  for (size_t i = 0; i < a.rows(); ++i)
-    for (size_t j = 0; j < a.cols(); ++j)
+  for (size_t i = 0; i < a.rows(); ++i) {
+    for (size_t j = 0; j < a.cols(); ++j) {
       if (a[{i, j}] != b[{i, j}])
         return false;
+    }
+  }
   return true;
 }
 

--- a/test/number_theory/chinese_remainder_theorem_test.cpp
+++ b/test/number_theory/chinese_remainder_theorem_test.cpp
@@ -32,7 +32,7 @@ class ChineseRemainderTheoremTest : public ::testing::Test {
 
 protected:
   void check(const std::vector<int_t>& a, const std::vector<int_t>& m) {
-    assert(a.size() > 0 && a.size() == m.size());
+    assert(!a.empty() && a.size() == m.size());
     ASSERT_TRUE(pairwise_coprime(m));
     const int_t x = chinese_remainder_theorem(a, m);
     EXPECT_LE(0, x);

--- a/test/number_theory/modular_test.cpp
+++ b/test/number_theory/modular_test.cpp
@@ -134,21 +134,43 @@ protected:
 } // end anonymous namespace
 
 TEST_F(ModInverseTest, PrimeModulesTest) {
-  set_mod(2), check_inverses(1, 1);
-  set_mod(3), check_inverses(2, 2);
-  set_mod(7), check_inverses(2, 4);
-  set_mod(47), check_inverses(6, 8);
-  set_mod(373), check_inverses(17, 22);
-  set_mod(7919), check_inverses(55, 144);
-  set_mod(1000000007), check_inverses(504, 1984127);
-  set_mod(2147483647), check_inverses(32768, 65536);
+  set_mod(2);
+  check_inverses(1, 1);
+
+  set_mod(3);
+  check_inverses(2, 2);
+
+  set_mod(7);
+  check_inverses(2, 4);
+
+  set_mod(47);
+  check_inverses(6, 8);
+
+  set_mod(373);
+  check_inverses(17, 22);
+
+  set_mod(7919);
+  check_inverses(55, 144);
+
+  set_mod(1000000007);
+  check_inverses(504, 1984127);
+
+  set_mod(2147483647);
+  check_inverses(32768, 65536);
 }
 
 TEST_F(ModInverseTest, NonPrimeModulesTest) {
-  set_mod(1), check_inverses(0, 0);
-  set_mod(4), check_inverses(1, 1);
-  set_mod(8), check_inverses(3, 3);
-  set_mod(9), check_inverses(2, 5);
+  set_mod(1);
+  check_inverses(0, 0);
+
+  set_mod(4);
+  check_inverses(1, 1);
+
+  set_mod(8);
+  check_inverses(3, 3);
+
+  set_mod(9);
+  check_inverses(2, 5);
 
   set_mod(63);
   check_inverses(1, 1);

--- a/test/number_theory/square_root_test.cpp
+++ b/test/number_theory/square_root_test.cpp
@@ -44,32 +44,32 @@ public:
   }
 };
 
-static constexpr rare_int operator+(rare_int lhs, rare_int rhs) {
+constexpr rare_int operator+(rare_int lhs, rare_int rhs) {
   return rare_int{lhs.get() + rhs.get()};
 }
-static constexpr rare_int operator-(rare_int lhs, rare_int rhs) {
+constexpr rare_int operator-(rare_int lhs, rare_int rhs) {
   return rare_int{lhs.get() - rhs.get()};
 }
-static constexpr rare_int operator*(rare_int lhs, rare_int rhs) {
+constexpr rare_int operator*(rare_int lhs, rare_int rhs) {
   return rare_int{lhs.get() * rhs.get()};
 }
-static constexpr rare_int operator<<(rare_int num, unsigned b) {
+constexpr rare_int operator<<(rare_int num, unsigned b) {
   return rare_int{num.get() << b};
 }
-static constexpr bool operator==(unsigned lhs, rare_int rhs) {
+constexpr bool operator==(unsigned lhs, rare_int rhs) {
   return lhs == rhs.get();
 }
-static constexpr bool operator<(rare_int lhs, rare_int rhs) {
+constexpr bool operator<(rare_int lhs, rare_int rhs) {
   return lhs.get() < rhs.get();
 }
-static constexpr bool operator<=(rare_int lhs, rare_int rhs) {
+constexpr bool operator<=(rare_int lhs, rare_int rhs) {
   return lhs.get() <= rhs.get();
 }
-static constexpr bool operator>(rare_int lhs, rare_int rhs) {
+constexpr bool operator>(rare_int lhs, rare_int rhs) {
   return lhs.get() > rhs.get();
 }
 
-static double sqrt(rare_int x) {
+double sqrt(rare_int x) {
   if (x.get() < 1000)
     return std::sqrt(x.get());
   if (x.get() % 2 == 0)
@@ -77,7 +77,7 @@ static double sqrt(rare_int x) {
   return std::sqrt(x.get()) - 5;
 }
 
-static std::ostream& operator<<(std::ostream& os, rare_int num) {
+std::ostream& operator<<(std::ostream& os, rare_int num) {
   return os << num.get();
 }
 } // end anonymous namespace

--- a/test/sorting/counting_sort_test.cpp
+++ b/test/sorting/counting_sort_test.cpp
@@ -22,7 +22,7 @@ TEST(CountingSortTest, Sorts) {
 
   const auto minmax = std::minmax_element(vec.begin(), vec.end());
   const int base = *minmax.first;
-  const size_t num_keys = *minmax.second - *minmax.first + 1;
+  const auto num_keys = static_cast<size_t>(*minmax.second - *minmax.first) + 1;
   auto get_key = [base](const int x) -> size_t { return x - base; };
 
   counting_sort(vec.begin(), vec.end(), num_keys, get_key);

--- a/test/utility/matrix_test.cpp
+++ b/test/utility/matrix_test.cpp
@@ -73,9 +73,10 @@ TEST(MatrixTest, AssignDefaultTest) {
   mat.assign({3, 4});
   ASSERT_EQ(3, mat.rows());
   ASSERT_EQ(4, mat.cols());
-  for (size_t i = 0; i != mat.rows(); ++i)
+  for (size_t i = 0; i != mat.rows(); ++i) {
     for (size_t j = 0; j != mat.cols(); ++j)
       EXPECT_EQ(0, (mat[{i, j}])) << " at (" << i << ", " << j << ")";
+  }
 }
 
 TEST(MatrixTest, AssignWithFillValueTest) {
@@ -83,7 +84,8 @@ TEST(MatrixTest, AssignWithFillValueTest) {
   mat.assign({5, 4}, 7);
   ASSERT_EQ(5, mat.rows());
   ASSERT_EQ(4, mat.cols());
-  for (size_t i = 0; i != mat.rows(); ++i)
+  for (size_t i = 0; i != mat.rows(); ++i) {
     for (size_t j = 0; j != mat.cols(); ++j)
       EXPECT_EQ(7, (mat[{i, j}])) << " at (" << i << ", " << j << ")";
+  }
 }


### PR DESCRIPTION
All warnings coming from the new checks integrated into ClangTidy 3.9 have been silenced. The only exception is the 'geometry' module. This module needs an independent refactor due to its overuse of commas in the unit tests.
