### PR TITLE
Refactor shoelace

### DIFF
--- a/include/cpl/geometry/shoelace.hpp
+++ b/include/cpl/geometry/shoelace.hpp
@@ -17,16 +17,16 @@ namespace cpl {
 
 /// \brief Computes the area of a simple polygon.
 ///
-/// Uses the Gauss's area formula to compute the area of the polygon \p poly.
+/// Uses the Gauss's area formula to compute the area of the polygon `poly`.
 ///
 /// \param poly The polygon to determine area.
 ///
-/// \pre <tt>poly.size() >= 3</tt>
+/// \pre `poly.size() >= 3`
 ///
-/// \returns Twice the area of the polygon \p poly.
+/// \returns **Twice** the area of the polygon `poly`.
 ///
 /// \par Complexity
-/// Linear in <tt>poly.size()</tt>.
+/// Linear in `poly.size()`.
 ///
 template <typename T>
 T shoelace_area(const std::vector<point2d<T>>& poly) {
@@ -40,6 +40,25 @@ T shoelace_area(const std::vector<point2d<T>>& poly) {
   sum += poly[0].x * (poly[1].y - poly[n - 1].y);
   sum += poly[n - 1].x * (poly[0].y - poly[n - 2].y);
   return std::abs(sum);
+}
+
+/// \brief Computes the area of a simple polygon.
+///
+/// \param poly The input polygon.
+///
+/// \pre `poly.size() >= 3`
+///
+/// \returns The computed area.
+///
+/// \par Complexity
+/// Linear in `poly.size()`
+///
+/// \note If `T` is an integer type the result might not be representable on
+/// this type.
+///
+template <typename T>
+T compute_polygon_area(const std::vector<point2d<T>>& poly) {
+  return shoelace_area(poly) / T{2};
 }
 
 } // end namespace cpl

--- a/include/cpl/geometry/shoelace.hpp
+++ b/include/cpl/geometry/shoelace.hpp
@@ -6,7 +6,7 @@
 #ifndef CPL_GEOMETRY_SHOELACE_HPP
 #define CPL_GEOMETRY_SHOELACE_HPP
 
-#include <cpl/geometry/point_2d.hpp> // point
+#include <cpl/geometry/point_2d.hpp> // point2d
 #include <cassert>                   // assert
 #include <cmath>                     // abs(Float)
 #include <cstddef>                   // size_t
@@ -29,7 +29,7 @@ namespace cpl {
 /// Linear in <tt>poly.size()</tt>.
 ///
 template <typename T>
-T shoelace_area(const std::vector<point<T>>& poly) {
+T shoelace_area(const std::vector<point2d<T>>& poly) {
   assert(poly.size() >= 3);
   using std::size_t;
 

--- a/test/geometry/shoelace_test.cpp
+++ b/test/geometry/shoelace_test.cpp
@@ -11,6 +11,7 @@
 #include <vector>                    // vector
 
 using cpl::shoelace_area;
+using cpl::compute_polygon_area;
 using point_i = cpl::point2d<int>;
 
 TEST(ShoelaceTest, SimpleShapes) {
@@ -18,14 +19,17 @@ TEST(ShoelaceTest, SimpleShapes) {
   std::vector<point_i> poly = {{0, 0}, {0, 2}, {2, 2}, {2, 0}};
 
   EXPECT_EQ(8, shoelace_area(poly));
+  EXPECT_EQ(4, compute_polygon_area(poly));
 
   // A square with colinear lines
   poly = {{0, 0}, {0, 1}, {0, 2}, {1, 2}, {2, 2}, {2, 1}, {2, 0}, {1, 0}};
   EXPECT_EQ(8, shoelace_area(poly));
+  EXPECT_EQ(4, compute_polygon_area(poly));
 
   // A triangle
   poly = {{2, 6}, {6, 4}, {4, 1}};
   EXPECT_EQ(16, shoelace_area(poly));
+  EXPECT_EQ(8, compute_polygon_area(poly));
 }
 
 TEST(ShoelaceTest, NonConvexPolygon) {
@@ -33,4 +37,5 @@ TEST(ShoelaceTest, NonConvexPolygon) {
                                {3, 2}, {5, 1}, {6, 3}, {10, 3}, {8, 6},
                                {9, 4}, {3, 5}, {4, 6}};
   EXPECT_EQ(42, shoelace_area(poly));
+  EXPECT_EQ(21, compute_polygon_area(poly));
 }

--- a/test/geometry/shoelace_test.cpp
+++ b/test/geometry/shoelace_test.cpp
@@ -17,20 +17,20 @@ TEST(ShoelaceTest, SimpleShapes) {
   // A square
   std::vector<point_i> poly = {{0, 0}, {0, 2}, {2, 2}, {2, 0}};
 
-  EXPECT_EQ(shoelace_area(poly), 8);
+  EXPECT_EQ(8, shoelace_area(poly));
 
   // A square with colinear lines
   poly = {{0, 0}, {0, 1}, {0, 2}, {1, 2}, {2, 2}, {2, 1}, {2, 0}, {1, 0}};
-  EXPECT_EQ(shoelace_area(poly), 8);
+  EXPECT_EQ(8, shoelace_area(poly));
 
   // A triangle
   poly = {{2, 6}, {6, 4}, {4, 1}};
-  EXPECT_EQ(shoelace_area(poly), 16);
+  EXPECT_EQ(16, shoelace_area(poly));
 }
 
 TEST(ShoelaceTest, NonConvexPolygon) {
   std::vector<point_i> poly = {{1, 6}, {1, 3}, {1, 2}, {1, 1},  {2, 4},
                                {3, 2}, {5, 1}, {6, 3}, {10, 3}, {8, 6},
                                {9, 4}, {3, 5}, {4, 6}};
-  EXPECT_EQ(shoelace_area(poly), 42);
+  EXPECT_EQ(42, shoelace_area(poly));
 }

--- a/test/geometry/shoelace_test.cpp
+++ b/test/geometry/shoelace_test.cpp
@@ -7,13 +7,11 @@
 #include <cpl/geometry/shoelace.hpp>
 #include <gtest/gtest.h>
 
-#include <cpl/geometry/point_2d.hpp> // point
-#include <cstdint>                   // int32_t
+#include <cpl/geometry/point_2d.hpp> // point2d
 #include <vector>                    // vector
 
 using cpl::shoelace_area;
-using std::int32_t;
-using point_i = cpl::point<int32_t>;
+using point_i = cpl::point2d<int>;
 
 TEST(ShoelaceTest, SimpleShapes) {
   // A square


### PR DESCRIPTION
- Use `point2d` instead of `point`
- Add `compute_polygon_area`
- Clarify `shoelace_area` returns **twice** the area of the given polygon.
